### PR TITLE
Control parallel processes

### DIFF
--- a/src/icikt/__main__.py
+++ b/src/icikt/__main__.py
@@ -20,7 +20,7 @@ Options:
     --chunk=<chunkSize>         What should the size of the chunks be for multiprocessing [default: 1]?
     --output=<outname>          If you want to save results as a csv, specify the path/to/save/fileID
     --include=<includeOnly>     Only run correlations of specified columns/combinations
-    --nprocess=<nProcess>       How many multithreaded process to use. May speed up calculations. 'max' may be passed to use all cores. [default: 1]
+    --nprocess=<nProcess>       How many multithreaded process to use. May speed up calculations. 'all' may be passed to use all available cores. [default: 1]
     --samples=<sampleClasses>   Which samples are in which classes? Specify a path to a csv.
 
 """

--- a/src/icikt/__main__.py
+++ b/src/icikt/__main__.py
@@ -4,7 +4,7 @@ Python Information-Content-Informed Kendall Tau Correlation (ICIKT)
 
 
 Usage:
-    icikt.py iciktArray <dataFilePath> [--data-format=<format>] [--replace=<globalNA>] [--mode=<perspective>] [--scale=<scaleMax>] [--diag=<diagGood>] [--chunk=<chunkSize>] [--output=<outname>] [--include=<includeOnly>]
+    icikt.py iciktArray <dataFilePath> [--data-format=<format>] [--replace=<globalNA>] [--mode=<perspective>] [--scale=<scaleMax>] [--diag=<diagGood>] [--chunk=<chunkSize>] [--output=<outname>] [--include=<includeOnly>] [--nprocess=<nProcess>]
     icikt.py leftCensor <dataFilePath> [--data-format=<format>] [--replace=<globalNA>] [--samples=<sampleClasses>]
     icikt.py -h | --help
     icikt.py --version
@@ -20,6 +20,7 @@ Options:
     --chunk=<chunkSize>         What should the size of the chunks be for multiprocessing [default: 1]?
     --output=<outname>          If you want to save results as a csv, specify the path/to/save/fileID
     --include=<includeOnly>     Only run correlations of specified columns/combinations
+    --nprocess=<nProcess>       How many multithreaded process to use. May speed up calculations. [default: 1]
     --samples=<sampleClasses>   Which samples are in which classes? Specify a path to a csv.
 
 """
@@ -119,8 +120,13 @@ def main():
             log.error(f"Error: '{args['--chunk'] = }' is not a valid integer.")
             sys.exit(1)
 
+        try: 
+            int(args['--nprocess'])
+        except ValueError:
+            log.error(f"Error: '{args['--nprocess'] = }' is not a valid integer.")
+
         try:
-            out, corr, pVal, tMax = icikt.iciktArray(dataArray=args["<dataFilePath>"], globalNA=args["--replace"], perspective=args["--mode"], scaleMax=args["--scale"], diagGood=args["--diag"], chunkSize=int(args["--chunk"]), includeOnly=args['--include'])
+            out, corr, pVal, tMax = icikt.iciktArray(dataArray=args["<dataFilePath>"], globalNA=args["--replace"], perspective=args["--mode"], scaleMax=args["--scale"], diagGood=args["--diag"], chunkSize=int(args["--chunk"]), includeOnly=args['--include'], nProcess=args['--nprocess'])
 
             if args["--output"] is not None:
                 np.savetxt(args["--output"]+'outArray.csv', out, delimiter=',')

--- a/src/icikt/__main__.py
+++ b/src/icikt/__main__.py
@@ -20,7 +20,7 @@ Options:
     --chunk=<chunkSize>         What should the size of the chunks be for multiprocessing [default: 1]?
     --output=<outname>          If you want to save results as a csv, specify the path/to/save/fileID
     --include=<includeOnly>     Only run correlations of specified columns/combinations
-    --nprocess=<nProcess>       How many multithreaded process to use. May speed up calculations. [default: 1]
+    --nprocess=<nProcess>       How many multithreaded process to use. May speed up calculations. 'max' may be passed to use all cores. [default: 1]
     --samples=<sampleClasses>   Which samples are in which classes? Specify a path to a csv.
 
 """
@@ -120,13 +120,8 @@ def main():
             log.error(f"Error: '{args['--chunk'] = }' is not a valid integer.")
             sys.exit(1)
 
-        try: 
-            int(args['--nprocess'])
-        except ValueError:
-            log.error(f"Error: '{args['--nprocess'] = }' is not a valid integer.")
-
         try:
-            out, corr, pVal, tMax = icikt.iciktArray(dataArray=args["<dataFilePath>"], globalNA=args["--replace"], perspective=args["--mode"], scaleMax=args["--scale"], diagGood=args["--diag"], chunkSize=int(args["--chunk"]), includeOnly=args['--include'], nProcess=int(args['--nprocess']))
+            out, corr, pVal, tMax = icikt.iciktArray(dataArray=args["<dataFilePath>"], globalNA=args["--replace"], perspective=args["--mode"], scaleMax=args["--scale"], diagGood=args["--diag"], chunkSize=int(args["--chunk"]), includeOnly=args['--include'], nProcess=args['--nprocess'])
 
             if args["--output"] is not None:
                 np.savetxt(args["--output"]+'outArray.csv', out, delimiter=',')

--- a/src/icikt/__main__.py
+++ b/src/icikt/__main__.py
@@ -126,7 +126,7 @@ def main():
             log.error(f"Error: '{args['--nprocess'] = }' is not a valid integer.")
 
         try:
-            out, corr, pVal, tMax = icikt.iciktArray(dataArray=args["<dataFilePath>"], globalNA=args["--replace"], perspective=args["--mode"], scaleMax=args["--scale"], diagGood=args["--diag"], chunkSize=int(args["--chunk"]), includeOnly=args['--include'], nProcess=args['--nprocess'])
+            out, corr, pVal, tMax = icikt.iciktArray(dataArray=args["<dataFilePath>"], globalNA=args["--replace"], perspective=args["--mode"], scaleMax=args["--scale"], diagGood=args["--diag"], chunkSize=int(args["--chunk"]), includeOnly=args['--include'], nProcess=int(args['--nprocess']))
 
             if args["--output"] is not None:
                 np.savetxt(args["--output"]+'outArray.csv', out, delimiter=',')

--- a/src/icikt/methods.py
+++ b/src/icikt/methods.py
@@ -197,7 +197,7 @@ def iciktArray(dataArray: np.ndarray,
     :param diagGood: should the diagonal entries reflect how many entries in the sample were "good"?
     :param chunkSize: What should the size of the chunks be for multiprocessing? Default is 1.
     :param includeOnly: only run correlations of specified columns/combinations
-    :param nProcess: how many multithreaded processes to use. May speed up calculations. Default is 1. 'max' may be passed to use all cores.
+    :param nProcess: how many multithreaded processes to use. May speed up calculations. Default is 1. 'all' may be passed to use all available cores.
     :return: tuple of the output correlations, raw correlations, pvalues, and max tau 2d arrays
 
     Future Parameters:
@@ -211,13 +211,13 @@ def iciktArray(dataArray: np.ndarray,
 
     # check if we have an integer or string nProcess, and set the right number of things
     if isinstance(nProcess, str):
-        if nProcess == "max":
+        if nProcess == "all":
             nProcess = os.cpu_count()
         else:
             try: 
                 nProcess = int(nProcess)
             except ValueError:
-                log.warning("nProcess should have been an integer, or the string 'max', setting to 1 process.")
+                log.warning("nProcess should have been an integer, or the string 'all', setting to 1 process.")
                 nProcess = 1
 
 

--- a/src/icikt/methods.py
+++ b/src/icikt/methods.py
@@ -15,6 +15,7 @@ import numpy as np
 import typing as t
 import itertools as it
 import logging as log
+import os
 from scipy.stats import mstats_basic
 from scipy.stats import distributions
 from icikt.utility import setupMissingMatrix
@@ -196,7 +197,7 @@ def iciktArray(dataArray: np.ndarray,
     :param diagGood: should the diagonal entries reflect how many entries in the sample were "good"?
     :param chunkSize: What should the size of the chunks be for multiprocessing? Default is 1.
     :param includeOnly: only run correlations of specified columns/combinations
-    :param nProcess: how many multithreaded processes to use. May speed up calculations. Default is 1.
+    :param nProcess: how many multithreaded processes to use. May speed up calculations. Default is 1. 'max' may be passed to use all cores.
     :return: tuple of the output correlations, raw correlations, pvalues, and max tau 2d arrays
 
     Future Parameters:
@@ -207,6 +208,18 @@ def iciktArray(dataArray: np.ndarray,
 
     # Set the global variable globalData equal to the input dataArray
     shm = initialize_global_data(dataArray)
+
+    # check if we have an integer or string nProcess, and set the right number of things
+    if isinstance(nProcess, str):
+        if nProcess == "max":
+            nProcess = os.cpu_count()
+        else:
+            try: 
+                nProcess = int(nProcess)
+            except ValueError:
+                log.warning("nProcess should have been an integer, or the string 'max', setting to 1 process.")
+                nProcess = 1
+
 
     # bool array where the nans are True
     excludeLoc = setupMissingMatrix(dataArray, globalNA)

--- a/src/icikt/methods.py
+++ b/src/icikt/methods.py
@@ -184,7 +184,8 @@ def iciktArray(dataArray: np.ndarray,
                scaleMax: bool = True,
                diagGood: bool = True,
                chunkSize: int = 1,
-               includeOnly: tuple or int or float or None = None) -> tuple:
+               includeOnly: tuple or int or float or None = None,
+               nProcess: int = 1) -> tuple:
     """Calls iciKT to calculate ICI-Kendall-Tau between every combination of
     columns in the input 2d array, dataArray. Also replaces any instance of the globalNA in the array with np.nan.
 
@@ -195,6 +196,7 @@ def iciktArray(dataArray: np.ndarray,
     :param diagGood: should the diagonal entries reflect how many entries in the sample were "good"?
     :param chunkSize: What should the size of the chunks be for multiprocessing? Default is 1.
     :param includeOnly: only run correlations of specified columns/combinations
+    :param nProcess: how many multithreaded processes to use. May speed up calculations. Default is 1.
     :return: tuple of the output correlations, raw correlations, pvalues, and max tau 2d arrays
 
     Future Parameters:
@@ -255,7 +257,7 @@ def iciktArray(dataArray: np.ndarray,
                                                     dtype=dataArray.dtype)
 
         # calls iciKT to calculate ICIKendallTau for every combination in product and stores in a list]
-        with multiprocessing.get_context('spawn').Pool() as pool:
+        with multiprocessing.get_context('spawn').Pool(nProcess) as pool:
             tempList = pool.map(wrapperWithSharedMemory, pairwiseComparisons.T, chunksize=chunkSize)
     finally:
         shm.close()


### PR DESCRIPTION
Adds the option --nprocess (cli) and nProcess (api) to iciktArray to allow control of the size of the worker pool from multiprocessing.Pool

default is 1.

I have tested the cli and API on my personal machine, and it seems the number of workers is respected in both cases.